### PR TITLE
test if absolute links work

### DIFF
--- a/tech/channels/channel-closing.md
+++ b/tech/channels/channel-closing.md
@@ -37,7 +37,7 @@ A force close is performed by broadcasting a "commitment transaction", a transac
 
 The practical result of a force close is that both parties will receive their portion of the money in the channel, but the party that initiates the force close must wait anywhere from hours to weeks—the exact delay is negotiated by the nodes beforehand—to receive their funds.  This delay, referred to as `to_self_delay` in the LND documentation, provides the offline node a window of opportunity to come back online and verify  that the force-close was legitimate.  If the force-close was fraudulent, the peer can challenge it with a penalty transaction.
 
-Fraudulent force close transactions can also be detected and responded to by [Watchtower services](../research/watchtowers.md).
+Fraudulent force close transactions can also be detected and responded to by [Watchtower services](/tech/research/watchtowers.md).
 
 ### Fraudulent Force Close
 


### PR DESCRIPTION
By default, gitbook creates inter-article links using relative links: `../bitcoin/htlc.md`

Gitbook auto-updates these links when things move around.

The question is, what happens if I use absolute links from the root of the gitbook directory: `/tech/bitcoin/hltc.md`

- [ ] does the link work?
- [ ] does the link auto-update?

I've changed a single link to test this.