### PR TITLE
Update reference mistake in invoice.md

### DIFF
--- a/tech/lightning/invoice.md
+++ b/tech/lightning/invoice.md
@@ -104,5 +104,7 @@ Below is a sample invoice decoded using an invoice decoding tool.  The standard 
 
 1. [BOLT \#11](https://github.com/lightningnetwork/lightning-rfc/blob/master/11-payment-encoding.md) standards document
 2. [Lightning Payment Request Decoder](https://lndecode.com/) app
-3. ["Lightning Network Invoices"](https://blockfuse.io/blog/lightning-network-invoices/) , Blockfuse \(2018-12-08\)
+3. [Radar ION Invoice Decoder](https://ion.radar.tech/developers/#decode)
+4. [Lightning Decoder](https://lightningdecoder.com/) app
+5. ["Lightning Network Invoices"](https://blockfuse.io/blog/lightning-network-invoices/) , Blockfuse \(2018-12-08\)
 

--- a/tech/lightning/invoice.md
+++ b/tech/lightning/invoice.md
@@ -103,6 +103,6 @@ Below is a sample invoice decoded using an invoice decoding tool.  The standard 
 ## References
 
 1. [BOLT \#11](https://github.com/lightningnetwork/lightning-rfc/blob/master/11-payment-encoding.md) standards document
-2. [Lightning Decoder](https://lightningdecoder.com/) app
+2. [Lightning Payment Request Decoder](https://lndecode.com/) app
 3. ["Lightning Network Invoices"](https://blockfuse.io/blog/lightning-network-invoices/) , Blockfuse \(2018-12-08\)
 


### PR DESCRIPTION
The reference lightning decoder points to 'https://lightningdecoder.com/' when the Example Invoice in this article clearly comes from 'https://lndecode.com/'

<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

-->

---
title: 'Title guidelines'
description: 'Description guidelines'
type: < Copy | New Page | Edit | Proposal | Structural >
category:
---

##### Description

<!-- A description of what this PR aims to solve -->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Proofread
- [ ] Changes don't break existing behavior
- [ ] Guidelines have been reviewed and this PR adheres to all

##### Affected core subsystem(s)

<!-- Provide affected core subsystem(s) (i.e. production, staging, content, admin). -->

##### Testing

<!-- Why should the PR reviewer trust that this contribution is valuable? -->

##### Proof Read

<!-- For content, have you proofed your changes? Do they adhere to our content guidelines? Have you cited all your resources? -->

##### Refers/Fixes

<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue  -> Fixes: #102
  If your PR refers an issue -> Refs: #101
-->
