### PR TITLE
Update LND.conf for using tor

### DIFF
--- a/tutorials/nodes/tor.md
+++ b/tutorials/nodes/tor.md
@@ -76,11 +76,14 @@ Enable LND to connect to Tor:
   or update your `lnd.conf`:
 
 ```text
+[Application Options]
+nat=false
+listen=localhost
+
 [Tor]
 tor.active=true
 tor.v3=true
 tor.streamisolation=true
-listen=localhost
 ```
 
 **Linux Permissions Issues**


### PR DESCRIPTION
When following this guide I ran into a small misconfiguration when setting up a node with tor.

---
title: Tor guideline update
description: Fix small issue with lnd.conf for tor usage
type: Edit
category:
---

##### Description

Thank you for providing the proper flags for running LND with tor using lnd.conf, instead of just command line flags. However I noticed that listen=true was placed in the Tor section. When running in this configuration lnd doesn't start up, that flag belongs in the application options section. While doing this research, I also found nat=false to be useful when using tor, so I also included it here.

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X ] Proofread
- [ X] Changes don't break existing behavior
- [ X] Guidelines have been reviewed and this PR adheres to all

##### Affected core subsystem(s)

<!-- Provide affected core subsystem(s) (i.e. production, staging, content, admin). -->

##### Testing

<!-- Why should the PR reviewer trust that this contribution is valuable? -->

##### Proof Read

<!-- For content, have you proofed your changes? Do they adhere to our content guidelines? Have you cited all your resources? -->

##### Refers/Fixes

<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue  -> Fixes: #102
  If your PR refers an issue -> Refs: #101
-->
