### PR TITLE
Add info on tor permission persistences for Arch

### DIFF
--- a/tutorials/nodes/tor.md
+++ b/tutorials/nodes/tor.md
@@ -117,6 +117,14 @@ sudo chmod 750 /var/lib/tor
 sudo chmod 740 /var/lib/tor/control_auth_cookie
 ```
 
+These changes won't persist on reboot. Add the following to your torrc:
+```text
+  CookieAuthFileGroupReadable 1
+  DataDirectoryGroupReadable 1
+```
+
+See the [Arch tor wiki](https://wiki.archlinux.org/title/Tor) for further debugging and configuration.
+
 **Tor for multi-LND systems**
 
 If you want to run multiple instances of LND simulaneously on the same machine and have them use different Tor Hidden Service addresses, add this to `lnd.conf` \(a new private key will automatically be created if the file specified here does not exist\):


### PR DESCRIPTION
---
Add info on tor permission persistences for Arch
Description: On reboot the current setup fails on arch
type:  Edit 
---

##### Description

Self descriptive.

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Proofread
- [X] Changes don't break existing behavior
- [X] Guidelines have been reviewed and this PR adheres to all

##### Testing

I've tested it on my node. Rebooting now works, previously I had to amend the permissions on each reboot.
